### PR TITLE
allow substrings to replace a parameter's value

### DIFF
--- a/fryr.js
+++ b/fryr.js
@@ -165,39 +165,32 @@
     if(hash.indexOf(key) !== -1) {
       var key_value = param(key);
 
-      var regex_for_value = new RegExp(value, 'g');
+      // If the key is required or value isn't blank and is not in key_value
+      var value_not_in_key_value = key_value.split(',').indexOf(value) === -1;
+      if (key_is_required || (value_not_in_key_value && value !== '')) {
 
-      // If key_value contains the new value
-      if(regex_for_value.test(key_value)) {
+        // add the value, replacing it if necessary
+        addValue(key, value, should_replace_value);
 
-        // If key is required, swap it out
-        if(key_is_required) {
-          addValue(key, value, should_replace_value);
+      } else {
 
+        // If the value is blank, remove the original value from the key
+        if(value === '') {
+          removeValue(key, key_value);
+
+        // Otherwise remove the vanilla value if it's different than the original value
+        // or value should not be replaced (appended)
         } else {
-
-          // If the value is blank, remove the original value from the key
-          if(value === '') {
-            removeValue(key, key_value);
-
-          // Otherwise remove the vanilla value if it's different than the original value or value should not be replaced (appended)
-          } else {
-            if(key_value !== value || !should_replace_value) {
-              removeValue(key, value);
-            }
-
-          }
-
-          // If key's value is blank, remove it from hash
-          if(param(key) === '') {
-            removeKey(key);
+          if(key_value !== value || !should_replace_value) {
+            removeValue(key, value);
           }
 
         }
 
-      // key_value does not contain the new value
-      } else {
-        addValue(key, value, should_replace_value);
+        // If key's value is blank, remove it from hash
+        if(param(key) === '') {
+          removeKey(key);
+        }
 
       }
 

--- a/test/spec/FryrSpec.js
+++ b/test/spec/FryrSpec.js
@@ -52,6 +52,20 @@ describe('Fryr', function() {
       expect(window.location.hash).toEqual('#?location=eac,dentist&character=nemo');
     });
 
+    it('should replace values when update value is different', function() {
+      window.location.hash = '#?location=dentist';
+      fry.update('location', 'ocean');
+
+      expect(window.location.hash).toEqual('#?location=ocean');
+    });
+
+    it('should replace values when update value is slightly different', function() {
+      window.location.hash = '#?location=dentist';
+      fry.update('location', 'dentis');
+
+      expect(window.location.hash).toEqual('#?location=dentis');
+    });
+
     it('should not replace values when update value is the same', function() {
       window.location.hash = '#?location=dentist';
       fry.update('location', 'dentist');


### PR DESCRIPTION
@tshedor: I narrowed the problem down to `update` thinking a param value that is a substring of the original value is an item within a list that just need to be removed.

``` javascript
window.location.hash = '#?location=dentist';
fry.update('location', 'dentis');
// returns '#?location=t'
```

The solution was to update the regex that determines if the value exists in in the key_value. Now it splits the key_value at ',' and checks to see if the new value is in the array. The rest of the conditional shuffling was to get the test suite to pass all use cases (kudos on thoroughness).
