### PR TITLE
always fire callback on init if hash params are present

### DIFF
--- a/fryr.js
+++ b/fryr.js
@@ -242,12 +242,14 @@
 
     window.addEventListener('hashchange', hashCallback);
 
+    var has_hash_on_load = window.location.hash !== '';
+
     // Apply defaults (if present) to hash, which will file window.onhashchange
-    if( Object.keys(defaults).length && window.location.hash === '' ) {
+    if( Object.keys(defaults).length && !has_hash_on_load ) {
       this.merge(defaults, true);
 
     // Execute the callback on load
-    } else if(call_on_init) {
+    } else if(call_on_init || has_hash_on_load) {
       privateHashChange.call(this);
 
     }

--- a/fryr.js
+++ b/fryr.js
@@ -242,7 +242,7 @@
 
     window.addEventListener('hashchange', hashCallback);
 
-    var has_hash_on_load = window.location.hash !== '';
+    var has_hash_on_load = window.location.hash.length > 2;
 
     // Apply defaults (if present) to hash, which will file window.onhashchange
     if( Object.keys(defaults).length && !has_hash_on_load ) {


### PR DESCRIPTION
Opening this to start a discussion, because I'm not sure if this will break expected behavior.

I have a use case where I don't want Fryr to fire on load unless there are hash params in the URL. If feel like this would be a common use case. Turning off `call_on_init` will make it so it's never called on load. 

Is there another solution here? Otherwise I suggest the following change to always trigger the callbacks when hash params are present.

cc @tshedor @nilesvm @LeChin 
