### PR TITLE
filter out empty values in convert method

### DIFF
--- a/fryr.js
+++ b/fryr.js
@@ -331,6 +331,10 @@
         var key = keys[i];
         var value = obj[ key ];
 
+        if (value === '') {
+          continue;
+        }
+
         if( value.constructor === Array ) {
           value = value.join(',');
         }
@@ -342,6 +346,10 @@
 
         // Append key/value to new_hash
         new_hash += key + '=' + value;
+      }
+
+      if (new_hash === '?') {
+        new_hash = '';
       }
 
       return new_hash;

--- a/test/spec/FryrSpec.js
+++ b/test/spec/FryrSpec.js
@@ -360,6 +360,14 @@ describe('Fryr', function() {
       expect(str).toEqual('?character=dory&location=dentist');
     });
 
+    it('should delete empty hash values', function() {
+      window.location.hash = '#?location=dentist&character=nemo';
+      var obj = { 'location' : '' };
+      var str = fry.merge(obj);
+
+      expect(str).toEqual('?character=nemo');
+    });
+
   });
 
   describe('.destroy()', function() {


### PR DESCRIPTION
This will allow `merge` to remove keys with empty values (see the test case). 

I originally attempted to fix this directly in `merge`, but saw that `covert` didn't play well when you passed it an empty object. I found this approach easier, but I'm putting a little faith into the test suite that I didn't break other use cases of `convert`.

cc @tshedor 
